### PR TITLE
Fixed a bug that caused "myScroll" to be always empty.

### DIFF
--- a/src/ng-iscroll.js
+++ b/src/ng-iscroll.js
@@ -64,7 +64,7 @@ angular.module('ng-iscroll', []).directive('ngIscroll', function ()
       function setScroll()
       {
         if (scope.$parent.myScroll === undefined) {
-          scope.$parent.myScroll = [];
+          scope.$parent.myScroll = {};
         }
 
         scope.$parent.myScroll[scroll_key] = new IScroll(element[0], ngiScroll_opts);


### PR DESCRIPTION
Initialized the scope-bound variable "myScroll" as an object instead of an array.
